### PR TITLE
Implement trial checks for select functions

### DIFF
--- a/supabase/functions/_shared/supabaseAdmin.ts
+++ b/supabase/functions/_shared/supabaseAdmin.ts
@@ -1,0 +1,18 @@
+import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+export function createSupabaseAdminClient(): SupabaseClient {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+  if (!supabaseUrl || !supabaseServiceKey) {
+    throw new Error('Missing environment variables: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  }
+
+  return createClient(supabaseUrl, supabaseServiceKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add shared Supabase admin client helper
- gate `analyze-document` and `agent-draft` edge functions based on trial status
- increment trial usage counters
- ensure `analyze-document` calls pass `userId` from the client

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*