### PR TITLE
Apply trial limits to remaining AI edge functions

### DIFF
--- a/supabase/functions/generate-field-suggestion/index.ts
+++ b/supabase/functions/generate-field-suggestion/index.ts
@@ -1,18 +1,12 @@
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
 import { corsHeaders } from '../_shared/cors.ts';
 import { Anthropic } from 'npm:@anthropic-ai/sdk@0.22.0'; // Use a recent compatible version
-import { createClient, SupabaseClient } from 'npm:@supabase/supabase-js@^2.39.0'; // Use a recent compatible version
+import { createSupabaseAdminClient } from '../_shared/supabaseAdmin.ts';
+import type { SupabaseClient } from 'npm:@supabase/supabase-js@^2.39.0';
 
 
-// Initialize Supabase admin client for user authentication (optional but good practice)
-const supabaseUrl = Deno.env.get('SUPABASE_URL');
-const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
-
-if (!supabaseUrl || !supabaseServiceKey) {
-  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
-  throw new Error('Supabase environment variables are not set for function.');
-}
-const supabaseAdmin: SupabaseClient = createClient(supabaseUrl, supabaseServiceKey);
+// Initialize Supabase admin client for user authentication
+const supabaseAdmin: SupabaseClient = createSupabaseAdminClient();
 
 
 // Get Anthropic API Key
@@ -55,6 +49,43 @@ serve(async (req: Request) => {
       });
     }
     console.log(`User ${user.id} invoking generate-field-suggestion`);
+
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from('profiles')
+      .select('subscription_status, trial_ends_at, trial_ai_calls_used')
+      .eq('id', user.id)
+      .single();
+
+    if (profileError || !profile) {
+      console.error('Profile fetch error:', profileError);
+      return new Response(JSON.stringify({ error: 'User profile not found' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
+    const TRIAL_AI_CALL_LIMIT = 30;
+    const now = new Date();
+
+    if (profile.subscription_status === 'trialing') {
+      if (!profile.trial_ends_at || new Date(profile.trial_ends_at) < now) {
+        return new Response(JSON.stringify({ error: 'Trial expired' }), {
+          status: 403,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+      }
+      if ((profile.trial_ai_calls_used ?? 0) >= TRIAL_AI_CALL_LIMIT) {
+        return new Response(JSON.stringify({ error: 'Trial call limit reached' }), {
+          status: 403,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+      }
+    } else if (profile.subscription_status !== 'active') {
+      return new Response(JSON.stringify({ error: 'Subscription inactive' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
 
     // 2. Validate Request Method & Body
     if (req.method !== 'POST') {
@@ -102,6 +133,13 @@ serve(async (req: Request) => {
     const suggestion = claudeResponse.content[0].text.trim();
 
     console.log(`AI suggestion received: "${suggestion.substring(0,100)}..."`);
+
+    if (profile.subscription_status === 'trialing') {
+      await supabaseAdmin
+        .from('profiles')
+        .update({ trial_ai_calls_used: (profile.trial_ai_calls_used ?? 0) + 1 })
+        .eq('id', user.id);
+    }
 
     // 5. Return the suggestion
     return new Response(JSON.stringify({ suggestion: suggestion }), {


### PR DESCRIPTION
## Summary
- add trial/subscription check logic to `deep-research-agent`
- add the same checks to `generate-field-suggestion`
- use the shared `createSupabaseAdminClient` helper in both functions
- increment `trial_ai_calls_used` when a trial user successfully invokes these endpoints

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*