### PR TITLE
Add trial checks to more AI functions

### DIFF
--- a/src/pages/tools/IntelligentDraftingPage.tsx
+++ b/src/pages/tools/IntelligentDraftingPage.tsx
@@ -112,12 +112,17 @@ const IntelligentDraftingPage: React.FC = () => {
     setGeneratedDraft('');
 
     try {
+      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      if (authError || !user) {
+        throw new Error('User not authenticated');
+      }
       const params = {
         draft_type: draftType,
         prompt_details: promptDetails,
         document_context: documentContext.trim() || undefined,
         tone: toneOptions[toneIndex].value,
         length_preference: lengthOptions[lengthIndex].value,
+        userId: user.id,
       };
 
       const { data, error: funcError } = await supabase.functions.invoke(

--- a/src/services/documentAnalysisService.ts
+++ b/src/services/documentAnalysisService.ts
@@ -345,10 +345,16 @@ export const generateInlineTextService = async (
   payload: GenerateInlineTextPayload
 ): Promise<{ reader: ReadableStreamDefaultReader<Uint8Array> | null; error: string | null }> => {
   try {
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      console.error('generateInlineTextService: User not authenticated.', authError);
+      return { reader: null, error: 'User not authenticated' };
+    }
+
     // Invoke the function. The Supabase client handles the stream.
-    // The `data` field in the response should be a ReadableStream.
     const { data, error: invokeError } = await supabase.functions.invoke('generate-inline-text', {
-      body: { ...payload, stream: true }, // Ensure the edge function expects `stream: true`
+      body: { ...payload, stream: true, userId: user.id },
     });
 
     if (invokeError) {


### PR DESCRIPTION
## Summary
- update generate-inline-text edge function with trial validation and usage tracking
- update intelligent-drafting edge function with same logic
- include `userId` when invoking generate-inline-text and intelligent-drafting from the frontend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: numerous TypeScript errors)*