### PR TITLE
Add trial enforcement to summarize-text and claude-router

### DIFF
--- a/supabase/functions/summarize-text/index.ts
+++ b/supabase/functions/summarize-text/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { corsHeaders } from "../_shared/cors.ts";
 import { OpenAI } from "https://deno.land/x/openai@v4.48.2/mod.ts"; // Use Deno module
+import { createSupabaseAdminClient } from '../_shared/supabaseAdmin.ts';
 
 // Ensure OPENAI_API_KEY is set in Supabase Function settings
 const openai = new OpenAI({
@@ -15,6 +16,66 @@ serve(async (req)=>{
     });
   }
   try {
+    const supabaseAdmin = createSupabaseAdminClient();
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing Authorization header' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 401
+      });
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: userError } = await supabaseAdmin.auth.getUser(token);
+
+    if (userError || !user) {
+      const msg = userError?.message || 'Invalid token';
+      console.error('Auth Error:', msg);
+      return new Response(JSON.stringify({ error: msg }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 401
+      });
+    }
+
+    const userId = user.id;
+
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from('profiles')
+      .select('subscription_status, trial_ends_at, trial_ai_calls_used')
+      .eq('id', userId)
+      .single();
+
+    if (profileError || !profile) {
+      console.error('Profile fetch error:', profileError);
+      return new Response(JSON.stringify({ error: 'User profile not found' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 403
+      });
+    }
+
+    const TRIAL_AI_CALL_LIMIT = 30;
+    const now = new Date();
+
+    if (profile.subscription_status === 'trialing') {
+      if (!profile.trial_ends_at || new Date(profile.trial_ends_at) < now) {
+        return new Response(JSON.stringify({ error: 'Trial expired' }), {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          status: 403
+        });
+      }
+      if ((profile.trial_ai_calls_used ?? 0) >= TRIAL_AI_CALL_LIMIT) {
+        return new Response(JSON.stringify({ error: 'Trial call limit reached' }), {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          status: 403
+        });
+      }
+    } else if (profile.subscription_status !== 'active') {
+      return new Response(JSON.stringify({ error: 'Subscription inactive' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 403
+      });
+    }
+
     const payload = await req.json();
     const { textToSummarize, instructions, surroundingContext, stream = true } = payload; // Default stream to true
     if (!textToSummarize) {
@@ -74,6 +135,12 @@ ${surroundingContext}
               }
             }
             // Signal stream completion
+            if (profile.subscription_status === 'trialing') {
+              await supabaseAdmin
+                .from('profiles')
+                .update({ trial_ai_calls_used: (profile.trial_ai_calls_used ?? 0) + 1 })
+                .eq('id', userId);
+            }
             controller.enqueue(encoder.encode('data: [DONE]\n\n'));
             controller.close();
           } catch (streamError) {
@@ -111,6 +178,12 @@ ${surroundingContext}
       const content = response.choices[0]?.message?.content;
       if (!content) {
         throw new Error('OpenAI returned empty content.');
+      }
+      if (profile.subscription_status === 'trialing') {
+        await supabaseAdmin
+          .from('profiles')
+          .update({ trial_ai_calls_used: (profile.trial_ai_calls_used ?? 0) + 1 })
+          .eq('id', userId);
       }
       return new Response(JSON.stringify({
         result: content


### PR DESCRIPTION
## Summary
- update `summarize-text` function to validate auth, check subscription/trial limits and update usage count
- apply the same trial checks in `claude-router`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: request to https://registry.npmjs.org/vitest failed, reason: connect EHOSTUNREACH)*