### PR TITLE
Implement trial enforcement on remaining edge functions

### DIFF
--- a/supabase/functions/functions/create-template-from-ai/index.ts
+++ b/supabase/functions/functions/create-template-from-ai/index.ts
@@ -1,7 +1,8 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import { corsHeaders } from '../_shared/cors.ts';
 import { OpenAI } from 'npm:openai@^4.0.0'; // Use npm specifier
-import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { createSupabaseAdminClient } from '../_shared/supabaseAdmin.ts';
+import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 console.log('Initializing create-template-from-ai function...');
 
@@ -10,22 +11,7 @@ const AI_MODEL = 'gpt-4o-mini'; // Or 'gpt-4o', 'gpt-4-turbo', etc.
 const MAX_TOKENS_RESPONSE = 2000; // Adjust as needed for template length
 
 // Initialize Supabase Admin Client (for database operations)
-const supabaseUrl = Deno.env.get('SUPABASE_URL');
-const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
-
-if (!supabaseUrl || !supabaseServiceKey) {
-  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
-  // Optionally throw to prevent function execution without DB access
-}
-
-// Correctly call createClient with options object
-const supabaseAdmin: SupabaseClient = createClient(supabaseUrl!, supabaseServiceKey!, {
-  auth: { 
-      persistSession: false,
-      autoRefreshToken: false,
-      detectSessionInUrl: false
-  }
-});
+const supabaseAdmin: SupabaseClient = createSupabaseAdminClient();
 
 // --- Helper Function: Sanitize Name ---
 function sanitizeName(name: string): string {
@@ -56,6 +42,43 @@ serve(async (req: Request) => {
     }
 
     console.log(`Received request: userId=${userId}, category=${category}`);
+
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from('profiles')
+      .select('subscription_status, trial_ends_at, trial_ai_calls_used')
+      .eq('id', userId)
+      .single();
+
+    if (profileError || !profile) {
+      console.error('Profile fetch error:', profileError);
+      return new Response(JSON.stringify({ error: 'User profile not found' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
+    const TRIAL_AI_CALL_LIMIT = 30;
+    const now = new Date();
+
+    if (profile.subscription_status === 'trialing') {
+      if (!profile.trial_ends_at || new Date(profile.trial_ends_at) < now) {
+        return new Response(JSON.stringify({ error: 'Trial expired' }), {
+          status: 403,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+      }
+      if ((profile.trial_ai_calls_used ?? 0) >= TRIAL_AI_CALL_LIMIT) {
+        return new Response(JSON.stringify({ error: 'Trial call limit reached' }), {
+          status: 403,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+      }
+    } else if (profile.subscription_status !== 'active') {
+      return new Response(JSON.stringify({ error: 'Subscription inactive' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
 
     // 3. Initialize OpenAI Client
     const openaiApiKey = Deno.env.get('OPENAI_API_KEY');
@@ -161,6 +184,13 @@ IMPORTANT INSTRUCTIONS:
 
     const newTemplateId = dbData.id;
     console.log(`Template saved successfully with ID: ${newTemplateId}`);
+
+    if (profile.subscription_status === 'trialing') {
+      await supabaseAdmin
+        .from('profiles')
+        .update({ trial_ai_calls_used: (profile.trial_ai_calls_used ?? 0) + 1 })
+        .eq('id', userId);
+    }
 
     // 9. Return Success Response
     return new Response(


### PR DESCRIPTION
## Summary
- add subscription and trial verification to `generic-chat-agent`
- enforce trial checks on duplicate `create-template-from-ai`

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm run build` *(fails: TS errors)*